### PR TITLE
fix parser for computed properties with an explicit getter function

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -59,15 +59,14 @@ class Parser extends EventEmitter {
       entry.name = Object.keys(entry.value)[0]
       entry.value = entry.value[entry.name]
 
-      if (entry.value instanceof utils.NodeFunction) {
-        switch (property.key.name) {
-          case 'computed':
-            entry.dependencies = utils.getDependencies(entry.value, this.source.script)
-            break
-
-          default:
-            entry.params = entry.value.params
+      if (property.key.name === 'computed') {
+        if (entry.value instanceof utils.NodeFunction) {
+          entry.dependencies = utils.getDependencies(entry.value, this.source.script)
+        } else if (entry.value instanceof Object && entry.value.get instanceof utils.NodeFunction) {
+          entry.dependencies = utils.getDependencies(entry.value.get, this.source.script)
         }
+      } else if (entry.value instanceof utils.NodeFunction) {
+        entry.params = entry.value.params
       } else if (property.key.name === 'props') {
         if (entry.describeModel) {
           entry.name = 'v-model'

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -64,6 +64,8 @@ class Parser extends EventEmitter {
           entry.dependencies = utils.getDependencies(entry.value, this.source.script)
         } else if (entry.value instanceof Object && entry.value.get instanceof utils.NodeFunction) {
           entry.dependencies = utils.getDependencies(entry.value.get, this.source.script)
+        } else {
+          entry.dependencies = []
         }
       } else if (entry.value instanceof utils.NodeFunction) {
         entry.params = entry.value.params

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -60,6 +60,7 @@ class Parser extends EventEmitter {
       entry.value = entry.value[entry.name]
 
       if (property.key.name === 'computed') {
+        /* istanbul ignore else */
         if (entry.value instanceof utils.NodeFunction) {
           entry.dependencies = utils.getDependencies(entry.value, this.source.script)
         } else if (entry.value instanceof Object && entry.value.get instanceof utils.NodeFunction) {

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -60,11 +60,13 @@ class Parser extends EventEmitter {
       entry.value = entry.value[entry.name]
 
       if (property.key.name === 'computed') {
-        /* istanbul ignore else */
         if (entry.value instanceof utils.NodeFunction) {
           entry.dependencies = utils.getDependencies(entry.value, this.source.script)
         } else if (entry.value instanceof Object && entry.value.get instanceof utils.NodeFunction) {
           entry.dependencies = utils.getDependencies(entry.value.get, this.source.script)
+        } else {
+          const error = new Error('Computed property must be a function or an object with a get() function')
+          this.emit('error', error)
         }
       } else if (entry.value instanceof utils.NodeFunction) {
         entry.params = entry.value.params

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -64,9 +64,6 @@ class Parser extends EventEmitter {
           entry.dependencies = utils.getDependencies(entry.value, this.source.script)
         } else if (entry.value instanceof Object && entry.value.get instanceof utils.NodeFunction) {
           entry.dependencies = utils.getDependencies(entry.value.get, this.source.script)
-        } else {
-          const error = new Error('Computed property must be a function or an object with a get() function')
-          this.emit('error', error)
         }
       } else if (entry.value instanceof utils.NodeFunction) {
         entry.params = entry.value.params

--- a/test/integration.spec.js
+++ b/test/integration.spec.js
@@ -198,6 +198,12 @@ describe('component.computed', () => {
             },
             type () {
               return 'text'
+            },
+            getter: {
+              get () {
+                const value = this.value
+                return this.name + value
+              }
             }
           }
         }
@@ -209,13 +215,16 @@ describe('component.computed', () => {
     return parser.parse(options).then((component) => {
       const computed = component.computed
 
-      assert.equal(computed.length, 2)
+      assert.equal(computed.length, 3)
 
       assert.equal(computed[0].name, 'id')
       assert.deepEqual(computed[0].dependencies, [ 'value', 'name' ])
 
       assert.equal(computed[1].name, 'type')
       assert.deepEqual(computed[1].dependencies, [])
+
+      assert.equal(computed[2].name, 'getter')
+      assert.deepEqual(computed[2].dependencies, [ 'value', 'name' ])
     })
   })
 })

--- a/test/parser.spec.js
+++ b/test/parser.spec.js
@@ -506,6 +506,38 @@ describe('Parser', () => {
         })
       })
 
+      it('should emit event with invalid computed property', (done) => {
+        const filename = './fixtures/checkbox.vue'
+        const script = `
+          export default {
+            computed: {
+              /**
+               * ID computed prop
+               *
+               * @private
+               */
+              idGetter: {
+                foo () {
+                  const value = this.value
+                  return this.name + value
+                }
+              }
+            }
+          }
+        `
+        const options = {
+          source: { script },
+          filename
+        }
+        const parser = new Parser(options)
+
+        parser.walk().on('error', (err) => {
+          assert.ok(/Computed property must be a function or an object with a get\(\) function/.test(err.message))
+
+          done()
+        })
+      })
+
       it('should successfully emit an unknow item', (done) => {
         const filename = './fixtures/checkbox.vue'
         const defaultMethodVisibility = 'public'

--- a/test/parser.spec.js
+++ b/test/parser.spec.js
@@ -463,6 +463,49 @@ describe('Parser', () => {
         })
       })
 
+      it('should successfully emit a computed property item with a getter', (done) => {
+        const filename = './fixtures/checkbox.vue'
+        const script = `
+          export default {
+            computed: {
+              /**
+               * ID computed prop
+               *
+               * @private
+               */
+              idGetter: {
+                get () {
+                  const value = this.value
+                  return this.name + value
+                }
+              }
+            }
+          }
+        `
+        const options = {
+          source: { script },
+          filename
+        }
+        const parser = new Parser(options)
+        const expected = {
+          name: 'idGetter',
+          keywords: [{ name: 'private', description: '' }],
+          visibility: 'private',
+          description: 'ID computed prop',
+          dependencies: ['value', 'name']
+        }
+
+        parser.walk().on('computed', (prop) => {
+          assert.equal(prop.name, expected.name)
+          assert.deepEqual(prop.keywords, expected.keywords)
+          assert.equal(prop.visibility, expected.visibility)
+          assert.equal(prop.description, expected.description)
+          assert.equal(prop.value.get.type, 'FunctionExpression')
+          assert.deepEqual(prop.dependencies, expected.dependencies)
+          done()
+        })
+      })
+
       it('should successfully emit an unknow item', (done) => {
         const filename = './fixtures/checkbox.vue'
         const defaultMethodVisibility = 'public'

--- a/test/parser.spec.js
+++ b/test/parser.spec.js
@@ -506,6 +506,37 @@ describe('Parser', () => {
         })
       })
 
+      it('should ignore functions other than get on computed property', (done) => {
+        const filename = './fixtures/checkbox.vue'
+        const script = `
+          export default {
+            computed: {
+              /**
+               * ID computed prop
+               *
+               * @private
+               */
+              idGetter: {
+                foo () {
+                  const value = this.value
+                  return this.name + value
+                }
+              }
+            }
+          }
+        `
+        const options = {
+          source: { script },
+          filename
+        }
+        const parser = new Parser(options)
+
+        parser.walk().on('computed', (prop) => {
+          assert.ok(typeof prop.dependencies === 'undefined')
+          done()
+        })
+      })
+
       it('should successfully emit an unknow item', (done) => {
         const filename = './fixtures/checkbox.vue'
         const defaultMethodVisibility = 'public'

--- a/test/parser.spec.js
+++ b/test/parser.spec.js
@@ -532,7 +532,7 @@ describe('Parser', () => {
         const parser = new Parser(options)
 
         parser.walk().on('computed', (prop) => {
-          assert.ok(typeof prop.dependencies === 'undefined')
+          assert.deepEqual(prop.dependencies, [])
           done()
         })
       })

--- a/test/parser.spec.js
+++ b/test/parser.spec.js
@@ -506,38 +506,6 @@ describe('Parser', () => {
         })
       })
 
-      it('should emit event with invalid computed property', (done) => {
-        const filename = './fixtures/checkbox.vue'
-        const script = `
-          export default {
-            computed: {
-              /**
-               * ID computed prop
-               *
-               * @private
-               */
-              idGetter: {
-                foo () {
-                  const value = this.value
-                  return this.name + value
-                }
-              }
-            }
-          }
-        `
-        const options = {
-          source: { script },
-          filename
-        }
-        const parser = new Parser(options)
-
-        parser.walk().on('error', (err) => {
-          assert.ok(/Computed property must be a function or an object with a get\(\) function/.test(err.message))
-
-          done()
-        })
-      })
-
       it('should successfully emit an unknow item', (done) => {
         const filename = './fixtures/checkbox.vue'
         const defaultMethodVisibility = 'public'


### PR DESCRIPTION
Hi, I added a small fix for parsing computed properties that use the [getter/setter syntax](https://vuejs.org/v2/guide/computed.html#Computed-Setter). Currently this breaks with the following error:

    /path/to/node_modules/@vuedoc/md/lib/markdown.js:130
          if (prop.dependencies.length) {
                               ^
    
    TypeError: Cannot read property 'length' of undefined
        at props.forEach (/path/to/node_modules/@vuedoc/md/lib/markdown.js:130:28)
        at Array.forEach (native)
        at Object.computed (/path/to/node_modules/@vuedoc/md/lib/markdown.js:121:11)
        at options.printOrder.forEach (/path/to/node_modules/@vuedoc/md/lib/markdown.js:218:19)
        at Array.forEach (native)
        at process.nextTick (/path/to/node_modules/@vuedoc/md/lib/markdown.js:207:24)
        at _combinedTickCallback (internal/process/next_tick.js:73:7)
        at process._tickCallback (internal/process/next_tick.js:104:9)

I'd appreciate it if you could merge this PR.