### PR TITLE
fix unCamelcase

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -216,7 +216,7 @@ const unCamelcase = (text) => {
   const chars = []
 
   text.split('').forEach((char) => {
-    if (char !== '-' && char === char.toUpperCase()) {
+    if (/[A-Z]/.test(char)) {
       char = char.toLowerCase()
 
       if (chars.length) {

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -471,6 +471,14 @@ describe('libutils', () => {
 
       assert.equal(result, entry)
     })
+
+    it('should succeed with entry that contains numbers', () => {
+      const entry = 'i18n'
+      const result = utils.unCamelcase(entry)
+      const expected = 'i18n'
+
+      assert.equal(result, expected)
+    })
   })
 
   describe('getDependencies(ast, source)', () => {


### PR DESCRIPTION
if text contains number,like i18n,expect to get i18n rather than i-1-8n #15 